### PR TITLE
fix: timezone of updated_date

### DIFF
--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -12,7 +12,7 @@ HATENA_ID="kokoichi206"
 BLOG_ID="koko206.hatenablog.com"
 
 AUTHOR="kokoichi206"
-UPDATED_DATE="$(date +"%Y-%m-%dT%H:%M:%S")"
+UPDATED_DATE="$(TZ=Asia/Tokyo date +"%Y-%m-%dT%H:%M:%S")"
 DRAFT="yes"
 PREVIEW="yes"
 


### PR DESCRIPTION
The drafted_post from cd is posted at UTC timezone.

<img width="274" alt="Screenshot 2024-10-11 at 0 04 29" src="https://github.com/user-attachments/assets/2892adbc-15d7-481c-ab4b-873431c07546">
