### PR TITLE
workflow_dispatch でファイルを指定して手動アップロードできるようにする

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,6 +5,12 @@ on:
       - main
     paths:
       - 'articles/**'
+  workflow_dispatch:
+    inputs:
+      file:
+        description: 'Path to the markdown file to upload (e.g. articles/2025-base.md)'
+        required: true
+        type: string
 
 jobs:
   draft-release:
@@ -18,9 +24,14 @@ jobs:
       - name: Upload article to Hatena Blog
         env:
           HATENA_API_KEY: ${{ secrets.HATENA_API_KEY }}
+          INPUT_FILE: ${{ inputs.file }}
         run: |
-          echo "Current SHA: ${{ github.workflow_sha }}"
-          CHANGED_MD_FILE=$(git diff-tree --no-commit-id --name-only -r ${{ github.workflow_sha }} | grep '\.md$' || true)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            CHANGED_MD_FILE="$INPUT_FILE"
+          else
+            echo "Current SHA: ${{ github.workflow_sha }}"
+            CHANGED_MD_FILE=$(git diff-tree --no-commit-id --name-only -r ${{ github.workflow_sha }} | grep '\.md$' || true)
+          fi
           echo "CHANGED_MD_FILE: ${CHANGED_MD_FILE}"
           if [ -n "$CHANGED_MD_FILE" ]; then
             echo "Uploading to Hatena Blog"


### PR DESCRIPTION
## 概要

`create-release` ワークフローに `workflow_dispatch` トリガーを追加し、アップロードする Markdown ファイルのパスを入力して手動実行できるようにした。既存の push ベースの自動アップロードはそのまま維持している。

## 変更点

- `workflow_dispatch.inputs.file`（必須）を追加。GitHub の Actions UI からファイルパスを入力して起動できる。
- `github.event_name` で分岐し、`workflow_dispatch` のときは入力ファイルを、`push` のときは従来どおり差分から `.md` を検出する。
- 入力値はコマンドインジェクション回避のため `env`（`INPUT_FILE`）経由で渡し、クォートして参照している。

## 使い方

main マージ後、Actions タブ → 「create draft release」→ 「Run workflow」で `file` に `articles/2025-base.md` のようにパスを入力して実行する。

## 注意

- `workflow_dispatch` の仕様上、main にマージされて初めて手動実行ボタンが表示される。
- 存在しないパスを渡した場合は `scripts/upload.sh` のファイル存在チェックでエラー終了する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)